### PR TITLE
Refactor leaderboard

### DIFF
--- a/db/phpmxbot.sql
+++ b/db/phpmxbot.sql
@@ -1,22 +1,28 @@
 -- Adminer 4.7.7 SQLite 3 dump
 
-DROP TABLE IF EXISTS "leaderboard";
-CREATE TABLE "leaderboard" (
-  "token" text NOT NULL,
-  "points" integer NOT NULL DEFAULT '0'
-);
-
-CREATE UNIQUE INDEX "leaderboard_token" ON "leaderboard" ("token");
-
-
 DROP TABLE IF EXISTS "login";
 CREATE TABLE "login" (
   "username" text NOT NULL,
   "password" text NOT NULL
 );
-
 CREATE UNIQUE INDEX "login_username" ON "login" ("username");
-
 INSERT INTO "login" ("username", "password") VALUES ('admin',	'%%PASSWORD_HASH%%');
+
+DROP TABLE IF EXISTS "leaderboard";
+CREATE TABLE "leaderboard" (
+  "token" text NOT NULL,
+  "user" text NOT NULL,
+  "points" integer(1) NOT NULL,
+  "method" text NOT NULL,
+  "timestamp" integer(10) NOT NULL
+);
+
+DROP TABLE IF EXISTS "leaderboard_month";
+CREATE VIEW "leaderboard_month" AS
+SELECT token, SUM(points) AS points
+FROM "leaderboard"
+WHERE timestamp >= strftime('%s', 'now', 'start of month')
+AND timestamp < strftime('%s', 'now', 'start of month', '+1 month')
+GROUP BY token;
 
 --

--- a/index.php
+++ b/index.php
@@ -20,7 +20,10 @@ $botman = BotManFactory::create($config);
 $botman->hears('.*(\+\+|\-\-).*', function (BotMan $bot) {
     $msg = $bot->getMessage()->getText();
     $tokens = PlusPlusHandler::tokenize($msg);
-    $points = PlusPlusHandler::updatePoints($tokens);
+
+    $payload = $bot->getMessage()->getPayload();
+    $user = $payload['user'] ?? 'unknown';
+    $points = PlusPlusHandler::updatePoints($user, $tokens);
 
     $bot->replyInThread('Points updated!', MessageHandler::arrayToBlocks($points));
 });


### PR DESCRIPTION
Refactor leaderboard to be a log of changes instead of the latest count. Also, added a view that acts as the original leaderboard but instead resets every month.

Resolves #4 
Resolves #5
