### PR TITLE
Add root user

### DIFF
--- a/migrate.sh
+++ b/migrate.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker run -ti --rm -v $PWD/db:/flyway/db -v $PWD/db/sql:/flyway/sql -v $PWD/db/conf:/flyway/conf flyway/flyway ${1:-migrate} -n
+docker run -ti --rm -v $PWD/db:/flyway/db -v $PWD/db/sql:/flyway/sql -v $PWD/db/conf:/flyway/conf --user root flyway/flyway ${1:-migrate} -n


### PR DESCRIPTION
@dmouse found that when `bootstrap.sh` is run in a Linux OS, the `db` folder has incorrect permissions and the sqlite cannot be configured.