### PR TITLE
Report shortcut (Demo)

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -4,9 +4,9 @@ use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
 use BotMan\BotMan\Drivers\DriverManager;
-use BotMan\Drivers\Slack\SlackDriver;
 use Symfony\Component\Dotenv\Dotenv;
 use BotMan\BotMan\BotMan;
+use PhpMx\Drivers\CustomDriver;
 use PhpMx\Router;
 
 require_once __DIR__ . '/../vendor/autoload.php';
@@ -22,7 +22,7 @@ $containerBuilder->compile(true);
 $botman = $containerBuilder->get(BotMan::class);
 $router = $containerBuilder->get(Router::class);
 
-DriverManager::loadDriver(SlackDriver::class);
+DriverManager::loadDriver(CustomDriver::class);
 $botman->loadDriver('Slack');
 $router->mount();
 

--- a/src/Conversation/Report.php
+++ b/src/Conversation/Report.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace PhpMx\Conversation;
+
+use BotMan\BotMan\BotMan;
+use Tightenco\Collect\Support\Collection;
+
+class Report implements ConversationInterface
+{
+    public function __invoke(Collection $event, BotMan $botman)
+    {
+        // Send a DM to a user when a report shortcut is called on a message.
+        $botman->say("Tu reporte ha sido recibido. Nos pondremos en contacto a la brevedad.", $event->get('user')['id']);
+    }
+
+    public function subscribe(BotMan $botman)
+    {
+        $botman->on('message_action', $this);
+    }
+}

--- a/src/Drivers/CustomDriver.php
+++ b/src/Drivers/CustomDriver.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace PhpMx\Drivers;
+
+use BotMan\BotMan\Drivers\Events\GenericEvent;
+use BotMan\Drivers\Slack\SlackDriver;
+use Tightenco\Collect\Support\Collection;
+
+class CustomDriver extends SlackDriver
+{
+    public function hasMatchingEvent()
+    {
+        /** @var Collection */
+        $payload = $this->payload;
+
+        // The value of `callback_id` is configured in Slack when creating the shortcut.
+        if ($payload->get('type') === 'message_action' && $payload->get('callback_id') === 'report_message') {
+            $event = new GenericEvent($payload);
+            $event->setName($payload->get('type'));
+
+            return $event;
+        }
+
+        parent::hasMatchingEvent();
+    }
+}


### PR DESCRIPTION
This is a quick demo to allow our bot to handle Slack shortcuts to report messages. These shortcuts must be setup in Slack before hand, including the value of `callback_id`.

A reference of the payload content can be seen at https://api.slack.com/reference/interaction-payloads/shortcuts.

![shortcut](https://user-images.githubusercontent.com/953140/99260590-97a57b80-27e9-11eb-9ce0-e28ade5e105d.gif)
